### PR TITLE
Adding :refer to async ns-form

### DIFF
--- a/src/tbd/core.cljs
+++ b/src/tbd/core.cljs
@@ -29,7 +29,8 @@
           [libname & opts] fst
           opts (apply hash-map opts)
           as (:as opts)
-          default (:default opts)]
+          default (:default opts)
+          refer (:refer opts)]
       (case libname
         ;; built-ins
         (reagent.core reagent.dom reagent.dom.server)
@@ -48,6 +49,9 @@
                      (when default
                        (sci/binding [sci/ns ns-obj]
                          (sci/eval-form @sci-ctx (list 'def default (.-default mod)))))
+                     (doseq [field refer]
+                       (sci/binding [sci/ns ns-obj]
+                         (sci/eval-form @sci-ctx (list 'def field (aget mod (str field))))))
                      (handle-libspecs ns-obj cb (next libspecs)))))))
     (cb ns-obj)))
 


### PR DESCRIPTION
This makes the following code:

```clojure
(ns some-sci-ns
  (:require [reagent.core :as r]
            ["ink" :refer [render Text]]))

(defonce state (r/atom 0))
(doseq [n (range 1 11)]
  (js/setTimeout #(swap! state inc) (* n 500)))

(defn hello []
  [:> Text {:color "green"} "Hello, world! " @state])

(render (r/as-element [hello]))
```

Work. You only need to run `npm i ink`